### PR TITLE
Add env variables support for execs on the docker infra.

### DIFF
--- a/api/model/model_types.go
+++ b/api/model/model_types.go
@@ -40,6 +40,7 @@ type MachineExec struct {
 	Tty        bool              `json:"tty"`
 	Cols       int               `json:"cols"`
 	Rows       int               `json:"rows"`
+	Env        map[string]string `json:"env"`
 
 	// unique client id, real execId should be hidden from client to prevent serialization
 	ID int `json:"id"`

--- a/exec/docker-infra/docker_exec_manager.go
+++ b/exec/docker-infra/docker_exec_manager.go
@@ -73,6 +73,7 @@ func (manager DockerMachineExecManager) Create(machineExec *model.MachineExec) (
 		AttachStderr: true,
 		Detach:       false,
 		Cmd:          machineExec.Cmd,
+		Env:          mapEnvToArray(machineExec.Env),
 	})
 	if err != nil {
 		return -1, err
@@ -92,6 +93,17 @@ func (manager DockerMachineExecManager) Create(machineExec *model.MachineExec) (
 	fmt.Println("Create exec ", machineExec.ID, "execId", machineExec.ExecId)
 
 	return machineExec.ID, nil
+}
+
+func mapEnvToArray(env map[string]string) []string {
+	var result = make([]string, 0)
+
+	for envKey, envValue := range env {
+		envItem := envKey + "=" + envValue
+		result = append(result, envItem)
+	}
+
+	return result
 }
 
 func (manager DockerMachineExecManager) Check(id int) (int, error) {


### PR DESCRIPTION
Add env variables option support for exec on the docker infra. Kubernetes/Openshift doesn't support this option, so we skip them. Needed for Theia terminal plugin api.

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>