### PR TITLE
rh-che-1061: Changing base image from centos to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ WORKDIR /go/src/github.com/ws-skeleton/che-machine-exec/
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-w -s' -a -installsuffix cgo -o che-machine-exec .
 
-FROM registry.centos.org/centos:7
+FROM alpine:3.8
+RUN apk add --no-cache ca-certificates
 COPY --from=builder /go/src/github.com/ws-skeleton/che-machine-exec/che-machine-exec /usr/local/bin
 ENTRYPOINT ["che-machine-exec"]


### PR DESCRIPTION
PR  reduces image size almost in 10 times (from 220 mb to 26 mb)

Tested PR on che.openshift.io:

1. Created workspace based on `Che 7 dev` stack
2. changed workspace attributes to point to the custom plugin:

```
  "attributes": {
    "che.server.secure_exposer": "jwtproxy",
    "plugins": "https://raw.githubusercontent.com/ibuziuk/my-che7-plugins/master/che-machine-exec-plugin:0.0.1",
    "editor": "org.eclipse.che.editor.theia:1.0.0"
  }
```
3. custom plugin uses `ibuziuk/che-machine-exec` image [1]
4. started workspace
5. check that terminal is working
6. machine exec plugin uses latest alphine linux
> / $ uname -r
> 3.10.0-862.11.6.el7.x86_64
> / $ cat /etc/issue
> Welcome to Alpine Linux 3.8
> Kernel \r on an \m (\l)
> 

[1] https://github.com/ibuziuk/my-che7-plugins/blob/master/che-machine-exec-plugin/0.0.1/che-plugin.yaml#L10